### PR TITLE
Allow buffer name customization

### DIFF
--- a/vterm-toggle.el
+++ b/vterm-toggle.el
@@ -49,6 +49,7 @@
 (declare-function vterm-send-return "vterm")
 (declare-function vterm-other-window "vterm")
 (defvar vterm-buffer-name  "*vterm*")
+(defvar vterm-toggle-buffer-name-fn nil)
 
 (defcustom vterm-toggle-show-hook nil
   "Hooks when swith to vterm buffer."
@@ -132,7 +133,9 @@ Optional argument ARGS ."
       (vterm-toggle-show)))))
 
 (defun vterm-toggle--buffer-name ()
-    vterm-buffer-name)
+  (if vterm-toggle-buffer-name-fn
+      (funcall vterm-toggle-buffer-name-fn)
+    vterm-buffer-name))
 
 ;;;###autoload
 (defun vterm-toggle-cd(&optional args)

--- a/vterm-toggle.el
+++ b/vterm-toggle.el
@@ -123,13 +123,16 @@ Optional argument ARGS ."
              vterm-toggle-hide-method))
     (if (equal (prefix-numeric-value args) 1)
         (vterm-toggle-hide)
-      (vterm vterm-buffer-name)))
+      (vterm (vterm-toggle--buffer-name))))
    ((equal (prefix-numeric-value args) 1)
     (vterm-toggle-show))
    ((equal (prefix-numeric-value args) 4)
     (let ((vterm-toggle-fullscreen-p
            (not vterm-toggle-fullscreen-p)))
       (vterm-toggle-show)))))
+
+(defun vterm-toggle--buffer-name ()
+    vterm-buffer-name)
 
 ;;;###autoload
 (defun vterm-toggle-cd(&optional args)
@@ -297,7 +300,7 @@ after you have toggle to the vterm buffer with `vterm-toggle'."
 (defun vterm-toggle--new(&optional buffer-name)
   "New vterm buffer."
   (let ((default-directory default-directory)
-        (buffer-name (or buffer-name vterm-buffer-name))
+        (buffer-name (or buffer-name (vterm-toggle--buffer-name)))
         project-root)
     (when (and vterm-toggle-project-root
                (eq vterm-toggle-scope 'project))


### PR DESCRIPTION
Hi,

first, thanks for this very nice package, I appropriate it a lot. :smiley:  

I had the following use case: I want my vterm buffer names to contain a the projectile project name.

This would have following benefits for me:
- Buffers opened by projectile are used by vterm-toggle and vice versa
- Buffers become easier to handle in `list-buffers` or `ibuffer`

I extracted the use of `vterm-buffer-name` into a function call and added an additional configuration parameter `vterm-toggle-buffer-name-fn` which can be set to a function providing the buffer name.

This allows me to supply my own buffer name function matching the projectile behavior, while keeping backwards compatibility.

```
    (defun my/vterm-toggle-buffer-name ()
      (if (projectile-project-root)
          (projectile-generate-process-name "vterm" nil (projectile-acquire-root))
        vterm-buffer-name))
    (setq vterm-toggle-buffer-name-fn 'my/vterm-toggle-buffer-name)
```

I am not super fluent in elisp, so please bear with me. 

Please let me know if such a change is fine for you and if I can change anything to make the code more idiomatic or better fitting into the project.

Thanks,
Chris
