### PR TITLE
Don’t update vterm-toggle--buffer-list when not toggled

### DIFF
--- a/vterm-toggle.el
+++ b/vterm-toggle.el
@@ -437,7 +437,8 @@ Optional argument ARGS optional args."
 
 (defun vterm-toggle--mode-hook()
   "Hook for `vterm-mode-hook'."
-  (add-to-list 'vterm-toggle--buffer-list (current-buffer)))
+  (when (vterm-toggle-togglable-buffer-p (current-buffer))
+    (add-to-list 'vterm-toggle--buffer-list (current-buffer))))
 (add-hook 'vterm-mode-hook #'vterm-toggle--mode-hook)
 
 (dolist (buf (buffer-list))


### PR DESCRIPTION
Follow up to #43. This is needed so new not togglable buffers don’t get in the buffer list. This is a requirement for me to filter out claude code buffers.

cc @jixiuf @knu 