### PR TITLE
Remove unnecessary (require 'vterm) at end of file

### DIFF
--- a/vterm-toggle.el
+++ b/vterm-toggle.el
@@ -477,8 +477,6 @@ If OFFSET is `non-nil', will goto next term buffer with OFFSET."
 
 (provide 'vterm-toggle)
 
-(require 'vterm nil t)                  ; https://github.com/jixiuf/vterm-toggle/issues/24
-
 ;; Local Variables:
 ;; coding: utf-8
 ;; End:


### PR DESCRIPTION
All vterm functions are already forward-declared with `declare-function`,
so byte-compilation produces no warnings without the require. At runtime,
vterm is always loaded before vterm-toggle is invoked (you need a vterm
buffer to exist before toggling).

The soft require was originally added for #24 but is no longer needed
given the `declare-function` forms already present in the file.